### PR TITLE
Experiment with using testdox flag in PHPUnit

### DIFF
--- a/KoansLib/KoanPrinter.php
+++ b/KoansLib/KoanPrinter.php
@@ -2,7 +2,7 @@
 namespace KoansLib;
 
 use PHPUnit\Framework\TestResult;
-use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\Util\TestDox\CliTestDoxPrinter;
 
 /**
  * Class KoanPrinter
@@ -11,8 +11,14 @@ use PHPUnit\TextUI\ResultPrinter;
  *
  * @package KoansLib
  */
-class KoanPrinter extends ResultPrinter
+class KoanPrinter extends CliTestDoxPrinter
 {
+    public function printResult(TestResult $result): void
+    {
+        $this->printHeader();
+
+        $this->printFooter($result);
+    }
 
     protected function printHeader(): void
     {

--- a/koans/AssertKoans.php
+++ b/koans/AssertKoans.php
@@ -56,11 +56,17 @@ class AssertKoans extends TestCase
         $this->assertEquals($expected_value, $actual_value);
     }
 
+    /**
+     * @testdox Sometimes we need to know the variable type.
+     */
     public function testSometimesWeNeedToKnowTheVariableType()
     {
         $this->assertEquals(__, gettype("What am I"));
     }
 
+    /**
+     * @testdox Sometimes we need to know the class type.
+     */
     public function testSometimesWeNeedToKnowTheClassType()
     {
         // See bottom of this file for class definition

--- a/koans/AssertKoans.php
+++ b/koans/AssertKoans.php
@@ -56,12 +56,12 @@ class AssertKoans extends TestCase
         $this->assertEquals($expected_value, $actual_value);
     }
 
-    public function testThatSometimesWeNeedToKnowTheVariableType()
+    public function testSometimesWeNeedToKnowTheVariableType()
     {
         $this->assertEquals(__, gettype("What am I"));
     }
 
-    public function testThatSometimesWeNeedToKnowTheClassType()
+    public function testSometimesWeNeedToKnowTheClassType()
     {
         // See bottom of this file for class definition
         $object = new Enlightenment();

--- a/koans/AssertKoans.php
+++ b/koans/AssertKoans.php
@@ -8,7 +8,7 @@ defined('__') or define('__', null);
 class AssertKoans extends TestCase
 {
     /**
-     * We shall contemplate truth by testing reality, via asserts.
+     * @testdox We shall contemplate truth by testing reality, via asserts.
      */
     public function testAssertTruth()
     {
@@ -17,7 +17,7 @@ class AssertKoans extends TestCase
     }
 
     /**
-     * Enlightenment may be more easily achieved with appropriate messages.
+     * @testdox Enlightenment may be more easily achieved with appropriate messages.
      */
     public function testAssertWithMessage()
     {
@@ -26,7 +26,7 @@ class AssertKoans extends TestCase
     }
 
     /**
-     * Sometimes we will ask you to fill in the values
+     * @testdox Sometimes we will ask you to fill in the values.
      */
     public function testFillInValues()
     {
@@ -35,18 +35,18 @@ class AssertKoans extends TestCase
     }
 
     /**
-     * To understand reality, we must compare our expectations against reality.
+     * @testdox To understand reality, we must compare our expectations against reality.
      */
     public function testAssertEquality()
     {
         $expected_value = __; // Replace __ with your answer
         $actual_value = 1 + 1;
-        
+
         $this->assertTrue($expected_value == $actual_value);
     }
 
     /**
-     * Some ways of asserting equality are better than others.
+     * @testdox Some ways of asserting equality are better than others.
      */
     public function testABetterWayToAssertEquality()
     {

--- a/koans/StringKoans.php
+++ b/koans/StringKoans.php
@@ -7,6 +7,9 @@ defined('__') or define('__', null);
 
 class StringKoans extends TestCase
 {
+    /**
+     * @testdox Double-quoted strings are strings.
+     */
     public function testDoubleQuotedStringsAreStrings()
     {
         $string = "Hello, world.";
@@ -15,6 +18,9 @@ class StringKoans extends TestCase
         $this->assertEquals(__, is_string($string));
     }
 
+    /**
+     * @testdox Single-quoted strings are also strings.
+     */
     public function testSingleQuotedStringsAreAlsoStrings()
     {
         $string = 'Goodbye, world.';
@@ -22,6 +28,9 @@ class StringKoans extends TestCase
         $this->assertEquals(__, is_string($string));
     }
 
+    /**
+     * @testdox Use the backslash for escaping quotes in strings.
+     */
     public function testUseBackslashForEscapingQuotesInStrings()
     {
         $a = "He said, \"Don't\"";
@@ -29,7 +38,10 @@ class StringKoans extends TestCase
 
         $this->assertEquals(__, ($a == $b));
     }
-    
+
+    /**
+     * @testdox Use single-quotes to create a string that contains double-quotes.
+     */
     public function testUseSingleQuotesToCreateAStringWithDoubleQuotes()
     {
         $string = 'He said, "Go Away."';
@@ -37,6 +49,9 @@ class StringKoans extends TestCase
         $this->assertEquals(__, $string); // Replace __ with a double quoted escaped version of the string
     }
 
+    /**
+     * @testdox Use double-quotes to create a string that contains single-quotes.
+     */
     public function testUseDoubleQuotesToCreateAStringWithSingleQuotes()
     {
         $string = "Don't";
@@ -44,6 +59,9 @@ class StringKoans extends TestCase
         $this->assertEquals(__, $string); // Replace __ with a single quoted escaped version of the string
     }
 
+    /**
+     * @testdox Strings can continue onto multiple lines.
+     */
     public function testStringsCanContinueOntoMultipleLines()
     {
         $string = "It was the best of times,
@@ -53,6 +71,9 @@ It was the worst of times.";
         $this->assertEquals(__, strlen($string));
     }
 
+    /**
+     * @testdox Strings can be wrapped in a heredoc syntax.
+     */
     public function testStringsCanBeWrappedInAHeredocSyntax()
     {
         $string = <<<EOT
@@ -64,6 +85,8 @@ EOT;
     }
 
     /**
+     * @testdox A heredoc identifier can be arbitrary.
+     *
      * Reference: https://secure.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
      */
     public function testHeredocIdentifierIsArbitrary()
@@ -76,6 +99,9 @@ OMPHALOSKEPSIS;
         $this->assertEquals(__, strlen($string));
     }
 
+    /**
+     * @testdox Strings can be wrapped in a nowdoc syntax.
+     */
     public function testStringsCanBeWrappedInANowdocSyntax()
     {
         // Note the single quotes around EOT, this is the Nowdoc syntax
@@ -87,6 +113,9 @@ EOT;
         $this->assertEquals(__, strlen($string));
     }
 
+    /**
+     * @testdox A dot concatenates strings.
+     */
     public function testDotConcatenatesStrings()
     {
         $string = "Hello, " . "World";
@@ -94,6 +123,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox Dot-concatenation works with variables.
+     */
     public function testDotWorksWithVariables()
     {
         $hi = "Hello, ";
@@ -103,6 +135,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox Dot-concatenation will not modify the original strings.
+     */
     public function testDotWillNotModifyOriginalStrings()
     {
         $hi = "Hello, ";
@@ -113,6 +148,9 @@ EOT;
         $this->assertEquals(__, $there);
     }
 
+    /**
+     * @testdox Dot-equals will append to the end of a string.
+     */
     public function testDotEqualsAppendsToEndOfString()
     {
         $hi = "Hello, ";

--- a/koans/StringKoans.php
+++ b/koans/StringKoans.php
@@ -53,7 +53,7 @@ It was the worst of times.";
         $this->assertEquals(__, strlen($string));
     }
 
-    public function testStringsCanBeWrappedInAHeardocSyntax()
+    public function testStringsCanBeWrappedInAHeredocSyntax()
     {
         $string = <<<EOT
 Howdy,

--- a/koans/StringManipulationKoans.php
+++ b/koans/StringManipulationKoans.php
@@ -39,6 +39,9 @@ class StringManipulationKoans extends TestCase
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox Heredoc interpolates like a double-quoted string
+     */
     public function testHeredocInterpolatesLikeDoubleQuotedStrings()
     {
         $value = "one";
@@ -49,6 +52,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox Nowdoc interpolates like a single-quoted string
+     */
     public function testNowdocInterpolatesLikeSingleQuotedStrings()
     {
         $value = "one";

--- a/koans/StringManipulationKoans.php
+++ b/koans/StringManipulationKoans.php
@@ -15,7 +15,7 @@ class StringManipulationKoans extends TestCase
         $this->assertEquals(__, $string);
     }
 
-    public function testStringInterpolationWontWorkInSingleQuotedString()
+    public function testStringInterpolationWillNotWorkInSingleQuotedString()
     {
         $value = "one";
         $string = 'The value is $value';

--- a/koans/StringManipulationKoans.php
+++ b/koans/StringManipulationKoans.php
@@ -42,7 +42,7 @@ class StringManipulationKoans extends TestCase
     /**
      * @testdox Heredoc interpolates like a double-quoted string
      */
-    public function testHeredocInterpolatesLikeDoubleQuotedStrings()
+    public function testHeredocInterpolatesLikeADoubleQuotedString()
     {
         $value = "one";
         $string = <<<EOT
@@ -55,7 +55,7 @@ EOT;
     /**
      * @testdox Nowdoc interpolates like a single-quoted string
      */
-    public function testNowdocInterpolatesLikeSingleQuotedStrings()
+    public function testNowdocInterpolatesLikeASingleQuotedString()
     {
         $value = "one";
         $string = <<<'EOT'

--- a/koans/StringManipulationKoans.php
+++ b/koans/StringManipulationKoans.php
@@ -7,6 +7,9 @@ defined('__') or define('__', null);
 
 class StringManipulationKoans extends TestCase
 {
+    /**
+     * @testdox One can interpolate variables in a double-quoted string.
+     */
     public function testStringInterpolationInDoubleQuotedString()
     {
         $value = "one";
@@ -15,6 +18,9 @@ class StringManipulationKoans extends TestCase
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox One cannot interpolate variables in a single-quoted string.
+     */
     public function testStringInterpolationWillNotWorkInSingleQuotedString()
     {
         $value = "one";
@@ -23,6 +29,9 @@ class StringManipulationKoans extends TestCase
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox Another option for variable iterpolation in a double-quoted string is with curly brackets.
+     */
     public function testStringInterpolationWithCurlyBrackets()
     {
         $value = "one";
@@ -31,6 +40,9 @@ class StringManipulationKoans extends TestCase
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox If one wants to interpolate associative array elements, one must use curly brackets.
+     */
     public function testInterpolatingAssociativeArrayElementsMustBeInCurlyBrackets()
     {
         $values = ["test" => "one", "foo" => "two"];
@@ -40,7 +52,7 @@ class StringManipulationKoans extends TestCase
     }
 
     /**
-     * @testdox Heredoc interpolates like a double-quoted string
+     * @testdox Heredoc interpolates like a double-quoted string.
      */
     public function testHeredocInterpolatesLikeADoubleQuotedString()
     {
@@ -53,7 +65,7 @@ EOT;
     }
 
     /**
-     * @testdox Nowdoc interpolates like a single-quoted string
+     * @testdox Nowdoc interpolates like a single-quoted string.
      */
     public function testNowdocInterpolatesLikeASingleQuotedString()
     {
@@ -65,6 +77,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox One can format a string using sprintf.
+     */
     public function testStringFormattingWithSprintf()
     {
         $product = "banana";
@@ -74,6 +89,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox When formatting a string with sprintf, use different type specifiers for the different types of variables.
+     */
     public function testStringFormattingWithSprintfTypeSpecifiers()
     {
         $product = "bananas";
@@ -86,6 +104,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox Complex string formatting can be done with sprintf.
+     */
     public function testComplexStringFormattingWithSprintf()
     {
         $product = "bananas";
@@ -103,6 +124,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox One can extract a substring from another string.
+     */
     public function testExtractAStringFromAString()
     {
         $string = "Bacon, lettuce and tomato";
@@ -110,6 +134,9 @@ EOT;
         $this->assertEquals(__, substr($string, 7, 10));
     }
 
+    /**
+     * @testdox One can get a single character from a string using an array index.
+     */
     public function testYouCanGetASingleCharacterFromAString()
     {
         $string = "Bacon, lettuce and tomato";
@@ -117,6 +144,9 @@ EOT;
         $this->assertEquals(__, $string[1]);
     }
 
+    /**
+     * @testdox Strings can be split.
+     */
     public function testStringsCanBeSplit()
     {
         $string = "Sausage Egg Cheese";
@@ -125,6 +155,9 @@ EOT;
         $this->assertEquals([__, __, __], $words);
     }
 
+    /**
+     * @testdox Strings can be joined.
+     */
     public function testStringsCanBeJoined()
     {
         $words = ["Now", "is", "the", "time"];
@@ -133,6 +166,9 @@ EOT;
         $this->assertEquals(__, $string);
     }
 
+    /**
+     * @testdox One can change the case of strings.
+     */
     public function testChangeCaseOfStrings()
     {
         $this->assertEquals(__, ucwords('one hand clap'));


### PR DESCRIPTION
This is based off of seeing the output when running `./contemplate-koans --testdox` for a pretty output.

Run `./contemplate-koans` for a really nice output of the passed koans and the first failed koan. This makes the test read more like an essay or a story.

This will require writing tests with function names that read well in English. Where punctuation is needed in the test name (like "won't" or "planes, trains, and automobiles"), use the `@testdox` annotation in that test's docblock. Otherwise, the wording will be based off of the camelCaseOfTheTestFunctionName.

![screenshot from 2018-07-30 23-31-48](https://user-images.githubusercontent.com/1981351/43437891-e93ee50a-9450-11e8-917c-1fd516a1a42a.png)