### PR TITLE
Editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
Add whitespace rules via editorconfig

This helps ensure that all files are using the same tabs vs spaces, line-endings, and basic whitespace rules.