### PR TITLE
Require a minimum version of PHP in order to use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
             "PhpKoans\\": "koans/"
         }
     },
+    "require": {
+        "php": "^7.1"
+    },
     "require-dev": {
         "phpunit/phpunit": "^7.1",
         "squizlabs/php_codesniffer": "^3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8aa5b8fb6f4478fd1f72023347b2f9f3",
+    "content-hash": "2957bc74a30eef11bf2e950923c37392",
     "packages": [],
     "packages-dev": [
         {
@@ -1518,6 +1518,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.1"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
In the `README.md`, we have a minimum version of PHP required to use this, but the `composer.json` does not have a minimum version listed.

This PR takes care of that. 

Added Bonus: If using PhpStorm with the [composer plugin](https://github.com/psliwa/idea-composer-plugin) enabled, the IDE environment will use inspections and such designed around that specified version of PHP.